### PR TITLE
Update docs for Anthropic embedding models

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@
 
 [Mem0](https://mem0.ai) ("mem-zero") enhances AI assistants and agents with an intelligent memory layer, enabling personalized AI interactions. It remembers user preferences, adapts to individual needs, and continuously learns over time—ideal for customer support chatbots, AI assistants, and autonomous systems.
 
+This fork focuses on using **Anthropic Claude** models for embeddings. Where the upstream project relied on OpenAI, embedding calls here default to Anthropic's API.
+
 ### Key Features & Use Cases
 
 **Core Capabilities:**

--- a/openmemory/CONTRIBUTING.md
+++ b/openmemory/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We welcome all forms of contributions:
 ### Backend Setup
 
 ```bash
-# Copy environment file and edit file to update OPENAI_API_KEY and other secrets
+# Copy environment file and edit it to add your Anthropic API keys
 make env
 
 # Build the containers
@@ -45,9 +45,9 @@ make ui-dev
 
 ### Prerequisites
 - Docker and Docker Compose
-- Python 3.9+ (for backend development)
+- Python 3.10+ (for backend development)
 - Node.js (for frontend development)
-- OpenAI API Key (for LLM interactions)
+- Anthropic API Key (for LLM interactions)
 
 ### Getting Started
 Follow the setup instructions in the README.md file to set up your development environment.

--- a/openmemory/README.md
+++ b/openmemory/README.md
@@ -2,14 +2,16 @@
 
 OpenMemory is your personal memory layer for LLMs - private, portable, and open-source. Your memories live locally, giving you complete control over your data. Build AI applications with personalized memories while keeping your data secure.
 
+This fork is tailored for use with **Anthropic Claude** embedding models. The original project relied on OpenAI embeddings, but all embedding-related functionality now defaults to Anthropic. You will need an Anthropic API key to run the backend services.
+
 ![OpenMemory](https://github.com/user-attachments/assets/3c701757-ad82-4afa-bfbe-e049c2b4320b)
 
 ## Prerequisites
 
 - Docker and Docker Compose
-- Python 3.9+ (for backend development)
+- Python 3.10+ (for backend development)
 - Node.js (for frontend development)
-- OpenAI API Key (required for LLM interactions, run `cp api/.env.example api/.env` then change **OPENAI_API_KEY** to yours)
+- Anthropic API Key (required for LLM interactions, run `cp api/.env.example api/.env` then set **LLM_API_KEY** and **EMBEDDING_MODEL_API_KEY**)
 
 ## Quickstart
 

--- a/openmemory/api/.env.example
+++ b/openmemory/api/.env.example
@@ -1,1 +1,4 @@
-OPENAI_API_KEY=sk-xxx
+LLM_PROVIDER=anthropic
+LLM_API_KEY=sk-your-anthropic-key
+EMBEDDING_MODEL_PROVIDER=anthropic
+EMBEDDING_MODEL_API_KEY=sk-your-anthropic-key

--- a/openmemory/api/Dockerfile
+++ b/openmemory/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.10-slim
 
 LABEL org.opencontainers.image.name="mem0/openmemory-mcp"
 

--- a/openmemory/api/README.md
+++ b/openmemory/api/README.md
@@ -16,7 +16,14 @@ make build
 make env
 ```
 
-Once you run this command, edit the file `api/.env` and enter the `OPENAI_API_KEY`.
+After running this command, edit the file `api/.env` and provide your Anthropic credentials:
+
+```
+LLM_PROVIDER=anthropic
+LLM_API_KEY=sk-your-anthropic-key
+EMBEDDING_MODEL_PROVIDER=anthropic
+EMBEDDING_MODEL_API_KEY=sk-your-anthropic-key
+```
 
 3. Start the services:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ packages = [
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.10,<4.0"
 qdrant-client = "^1.9.1"
 pydantic = "^2.7.3"
 openai = "^1.33.0"


### PR DESCRIPTION
## Summary
- update README to mention Anthropic Claude embeddings
- note Anthropic API keys in CONTRIBUTING instructions
- update OpenMemory API docs and example env file for Anthropic
- use Python 3.10 in OpenMemory API Dockerfile

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'google.generativeai')*